### PR TITLE
limit setuptools version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: |
             python3 -mvenv /usr/local/share/virtualenvs/tap-ringcentral
             source /usr/local/share/virtualenvs/tap-ringcentral/bin/activate
-            pip install -U 'pip<19.2' setuptools
+            pip install -U 'pip<19.2' 'setuptools<51.0.0'
             pip install .[dev]
       - add_ssh_keys
       - run:


### PR DESCRIPTION
# Description of change
Limit setuptools version to enable sourcing venv.

# Manual QA steps
 - None
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
