### PR TITLE
[SAC-28000] - GL - `OAuth 2.0 Authentication` to resolve authorization failures

### DIFF
--- a/tap_ringcentral/__init__.py
+++ b/tap_ringcentral/__init__.py
@@ -104,7 +104,7 @@ def main():
         'start_date'
     ])
 
-    client = RingCentralClient(args.config)
+    client = RingCentralClient(args.config, args.config_path)
 
     runner = RingCentralRunner(args, client)
 

--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -67,9 +67,8 @@ class RingCentralClient:
         response.raise_for_status()
         data = response.json()
 
-        # Rotate the refresh token if it’s due to expire within the next 24 hours (86400 seconds)
-        if data['refresh_token_expires_in'] <= 86400:
-            self.write_config({'refresh_token': data['refresh_token']})
+        # Rotate refresh_token on every refresh: each new access_token (3600s) invalidates the prior refresh_token.
+        self.write_config({'refresh_token': data['refresh_token']})
 
         return data['refresh_token'], data['access_token']
 

--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -7,11 +7,18 @@ import singer
 import singer.metrics
 
 from requests.auth import HTTPBasicAuth
+from datetime import datetime, timedelta
+
 
 LOGGER = singer.get_logger()  # noqa
 
 
 class APIException(Exception):
+    pass
+
+
+class AuthFailedException(APIException):
+    """Raised when authentication fails irrecoverably"""
     pass
 
 
@@ -24,15 +31,38 @@ class RingCentralClient:
         self.config_path = config_path
         self.base_url = self.config.get('api_url')
 
-        self.refresh_token, self.access_token = self.get_authorization()
+        self.refresh_token = self.config.get('refresh_token')
+        self.access_token = self.config.get('access_token')
+    
+        self.ensure_authorization()
 
     def write_config(self, data):
-        '''
-        Updates the provided filepath with json format of the `data` object
-        '''
         self.config.update(data)
         with open(self.config_path, "w") as tap_config:
             json.dump(self.config, tap_config, indent=2)
+
+    def is_refresh_token_expired(self):
+        expires_at = self.config.get('refresh_token_expires_at')
+        if not expires_at:
+            return True
+        return datetime.now() >= datetime.fromisoformat(expires_at)
+
+    def is_access_token_expired(self):
+        expires_at = self.config.get('access_token_expires_at')
+        if not expires_at:
+            return True
+        return datetime.now() >= datetime.fromisoformat(expires_at)
+
+    def ensure_authorization(self):
+        if self.is_refresh_token_expired():
+            LOGGER.error(
+                "Authentication failed: your refresh token has expired and must be rotated. "
+                "Please re-authenticate to obtain a new refresh token."
+            )
+            raise AuthFailedException("Refresh token expired - auth failed")
+
+        if self.is_access_token_expired():
+            self.get_authorization()
 
     def get_authorization(self):
         client_id = self.config.get('client_id')
@@ -56,11 +86,23 @@ class RingCentralClient:
             data=payload)
 
         response.raise_for_status()
-        json = response.json()
+        data = response.json()
 
-        self.write_config({'refresh_token': json['refresh_token']})
+        now = datetime.now()
+        access_token_expires_at = (now + timedelta(seconds=data['expires_in'])).isoformat()
+        refresh_token_expires_at = (now + timedelta(seconds=data['refresh_token_expires_in'])).isoformat()
 
-        return json['refresh_token'], json['access_token']
+        self.access_token = data['access_token']
+        self.refresh_token = data['refresh_token']
+
+        self.write_config({
+            'access_token': data['access_token'],
+            'expires_in': data['expires_in'],
+            'access_token_expires_at': access_token_expires_at,
+            'refresh_token': data['refresh_token'],
+            'refresh_token_expires_in': data['refresh_token_expires_in'],
+            'refresh_token_expires_at': refresh_token_expires_at
+        })
 
     @backoff.on_exception(backoff.expo,
                           APIException,

--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -2,7 +2,7 @@ import requests
 import base64
 import backoff
 import time
-
+import json
 import singer
 import singer.metrics
 
@@ -19,11 +19,20 @@ class RingCentralClient:
 
     MAX_TRIES = 7
 
-    def __init__(self, config):
+    def __init__(self, config, config_path):
         self.config = config
+        self.config_path = config_path
         self.base_url = self.config.get('api_url')
 
         self.refresh_token, self.access_token = self.get_authorization()
+
+    def write_config(self, data):
+        '''
+        Updates the provided filepath with json format of the `data` object
+        '''
+        self.config.update(data)
+        with open(self.config_path, "w") as tap_config:
+            json.dump(self.config, tap_config, indent=2)
 
     def get_authorization(self):
         client_id = self.config.get('client_id')
@@ -48,6 +57,14 @@ class RingCentralClient:
 
         response.raise_for_status()
         json = response.json()
+
+        self.write_config(
+            {
+                'access_token': json['access_token'],
+                'refresh_token': json['refresh_token']
+            }
+        )
+
         return json['refresh_token'], json['access_token']
 
     @backoff.on_exception(backoff.expo,

--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -58,12 +58,7 @@ class RingCentralClient:
         response.raise_for_status()
         json = response.json()
 
-        self.write_config(
-            {
-                'access_token': json['access_token'],
-                'refresh_token': json['refresh_token']
-            }
-        )
+        self.write_config({'refresh_token': json['refresh_token']})
 
         return json['refresh_token'], json['access_token']
 

--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -42,8 +42,6 @@ class RingCentralClient:
 
     def is_refresh_token_expired(self):
         expires_at = self.config.get('refresh_token_expires_at')
-        if not expires_at:
-            return True
         return datetime.now() >= datetime.fromisoformat(expires_at)
 
     def is_access_token_expired(self):
@@ -53,6 +51,9 @@ class RingCentralClient:
         return datetime.now() >= datetime.fromisoformat(expires_at)
 
     def ensure_authorization(self):
+        if 'refresh_token_expires_at' not in self.config:
+            self.get_authorization()
+            return
         if self.is_refresh_token_expired():
             LOGGER.error(
                 "Authentication failed: refresh token has expired and must be rotated. "

--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -67,7 +67,8 @@ class RingCentralClient:
         response.raise_for_status()
         data = response.json()
 
-        # Rotate refresh_token on every refresh: each new access_token (3600s) invalidates the prior refresh_token.
+        # Rotate refresh_token on every call.
+        # Each new access_token (expires_in: 3600s) invalidates the prior refresh_token.
         self.write_config({'refresh_token': data['refresh_token']})
 
         return data['refresh_token'], data['access_token']

--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -58,17 +58,18 @@ class RingCentralClient:
             headers=headers,
             data=payload)
 
-        if response.status_code == 400:
+        if response.status_code == 400 and 'invalid_grant' in response.text:
             LOGGER.error(
-                'Authentication failed: refresh token has expired and must be rotated. '
-                'Re-authenticate to obtain a new refresh token.'
+                'Authentication failed: refresh token is probably expired, invalid, revoked or malformed. '
+                'Re-authenticate to obtain a new refresh token and restore access.'
             )
-            raise AuthFailedException('Refresh token expired - auth failed')
+            raise AuthFailedException('Refresh token expired or invalid – auth failed')
 
         response.raise_for_status()
         data = response.json()
 
-        if data['refresh_token_expires_in'] <= 86400:  # If refresh_token is going to expire in a day, rotate it.
+        # Rotate the refresh token if it’s due to expire within the next 24 hours (86400 seconds)
+        if data['refresh_token_expires_in'] <= 86400:
             self.write_config({'refresh_token': data['refresh_token']})
 
         return data['refresh_token'], data['access_token']

--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -29,40 +29,12 @@ class RingCentralClient:
         self.config = config
         self.config_path = config_path
         self.base_url = self.config.get('api_url')
-
-        self.refresh_token = self.config.get('refresh_token')
-        self.access_token = self.config.get('access_token')
-    
-        self.ensure_authorization()
+        self.access_token = self.get_authorization()
 
     def write_config(self, data):
         self.config.update(data)
         with open(self.config_path, "w") as tap_config:
             json.dump(self.config, tap_config, indent=2)
-
-    def is_refresh_token_expired(self):
-        expires_at = self.config.get('refresh_token_expires_at')
-        return datetime.now() >= datetime.fromisoformat(expires_at)
-
-    def is_access_token_expired(self):
-        expires_at = self.config.get('access_token_expires_at')
-        if not expires_at:
-            return True
-        return datetime.now() >= datetime.fromisoformat(expires_at)
-
-    def ensure_authorization(self):
-        if 'refresh_token_expires_at' not in self.config:
-            self.get_authorization()
-            return
-        if self.is_refresh_token_expired():
-            LOGGER.error(
-                "Authentication failed: refresh token has expired and must be rotated. "
-                "Re-authenticate to obtain a new refresh token."
-            )
-            raise AuthFailedException("Refresh token expired - auth failed")
-
-        if self.is_access_token_expired():
-            self.get_authorization()
 
     def get_authorization(self):
         client_id = self.config.get('client_id')
@@ -85,24 +57,20 @@ class RingCentralClient:
             headers=headers,
             data=payload)
 
+        if response.status_code == 400:
+            LOGGER.error(
+                "Authentication failed: refresh token has expired and must be rotated. "
+                "Re-authenticate to obtain a new refresh token."
+            )
+            raise AuthFailedException("Refresh token expired - auth failed")
+
         response.raise_for_status()
         data = response.json()
 
-        now = datetime.now()
-        access_token_expires_at = (now + timedelta(seconds=data['expires_in'])).isoformat()
-        refresh_token_expires_at = (now + timedelta(seconds=data['refresh_token_expires_in'])).isoformat()
+        if data['refresh_token_expires_in'] <= 86400:  # If refresh_token is going to expire in a day, rotate it.
+            self.write_config({'refresh_token': data['refresh_token']})
 
-        self.access_token = data['access_token']
-        self.refresh_token = data['refresh_token']
-
-        self.write_config({
-            'access_token': data['access_token'],
-            'expires_in': data['expires_in'],
-            'access_token_expires_at': access_token_expires_at,
-            'refresh_token': data['refresh_token'],
-            'refresh_token_expires_in': data['refresh_token_expires_in'],
-            'refresh_token_expires_at': refresh_token_expires_at
-        })
+        return data['access_token']
 
     @backoff.on_exception(backoff.expo,
                           APIException,

--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -47,6 +47,7 @@ class RingCentralClient:
             headers=headers,
             data=body)
 
+        response.raise_for_status()
         json = response.json()
         return json['refresh_token'], json['access_token']
 

--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -29,7 +29,8 @@ class RingCentralClient:
         self.config = config
         self.config_path = config_path
         self.base_url = self.config.get('api_url')
-        self.access_token = self.get_authorization()
+
+        self.refresh_token, self.access_token = self.get_authorization()
 
     def write_config(self, data):
         self.config.update(data)
@@ -59,10 +60,10 @@ class RingCentralClient:
 
         if response.status_code == 400:
             LOGGER.error(
-                "Authentication failed: refresh token has expired and must be rotated. "
-                "Re-authenticate to obtain a new refresh token."
+                'Authentication failed: refresh token has expired and must be rotated. '
+                'Re-authenticate to obtain a new refresh token.'
             )
-            raise AuthFailedException("Refresh token expired - auth failed")
+            raise AuthFailedException('Refresh token expired - auth failed')
 
         response.raise_for_status()
         data = response.json()
@@ -70,7 +71,7 @@ class RingCentralClient:
         if data['refresh_token_expires_in'] <= 86400:  # If refresh_token is going to expire in a day, rotate it.
             self.write_config({'refresh_token': data['refresh_token']})
 
-        return data['access_token']
+        return data['refresh_token'], data['access_token']
 
     @backoff.on_exception(backoff.expo,
                           APIException,

--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -9,7 +9,6 @@ import singer.metrics
 from requests.auth import HTTPBasicAuth
 from datetime import datetime, timedelta
 
-
 LOGGER = singer.get_logger()  # noqa
 
 
@@ -56,8 +55,8 @@ class RingCentralClient:
     def ensure_authorization(self):
         if self.is_refresh_token_expired():
             LOGGER.error(
-                "Authentication failed: your refresh token has expired and must be rotated. "
-                "Please re-authenticate to obtain a new refresh token."
+                "Authentication failed: refresh token has expired and must be rotated. "
+                "Re-authenticate to obtain a new refresh token."
             )
             raise AuthFailedException("Refresh token expired - auth failed")
 

--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -6,6 +6,8 @@ import time
 import singer
 import singer.metrics
 
+from requests.auth import HTTPBasicAuth
+
 LOGGER = singer.get_logger()  # noqa
 
 
@@ -26,26 +28,25 @@ class RingCentralClient:
     def get_authorization(self):
         client_id = self.config.get('client_id')
         client_secret = self.config.get('client_secret')
-        basic_auth = base64.b64encode("{}:{}".format(client_id, client_secret).encode())
+        auth = HTTPBasicAuth(client_id, client_secret)
 
         body = {
-            'username': self.config.get('username'),
-            'password': self.config.get('password'),
-            'grant_type': 'password'
+            'code': self.config.get('authorization_code'),
+            'redirect_uri': self.config.get('redirect_uri'),
+            'grant_type': 'authorization_code'
         }
 
         headers = {
-            'Authorization': 'Basic {}'.format(basic_auth.decode()),
             'Content-Type': 'application/x-www-form-urlencoded'
         }
 
         response = requests.request(
             'POST',
             '{}/restapi/oauth/token'.format(self.base_url),
+            auth=auth,
             headers=headers,
             data=body)
 
-        response.raise_for_status()
         json = response.json()
         return json['refresh_token'], json['access_token']
 

--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -59,11 +59,9 @@ class RingCentralClient:
 
         if response.status_code == 400 and 'invalid_grant' in response.text:
             LOGGER.error(
-                'Authentication failed: refresh token is probably expired, invalid, revoked or malformed. '
-                'Re-authenticate to obtain a new refresh token and restore access. '
                 f'Response: {response.status_code} - {response.text}'
             )
-            raise AuthFailedException('Refresh token expired or invalid – auth failed')
+            raise AuthFailedException('Refresh token expired or invalid – auth failed. Re-authenticate to obtain a new refresh token and restore access.')
 
         response.raise_for_status()
         data = response.json()

--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -7,7 +7,6 @@ import singer
 import singer.metrics
 
 from requests.auth import HTTPBasicAuth
-from datetime import datetime, timedelta
 
 LOGGER = singer.get_logger()  # noqa
 

--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -30,10 +30,9 @@ class RingCentralClient:
         client_secret = self.config.get('client_secret')
         auth = HTTPBasicAuth(client_id, client_secret)
 
-        body = {
-            'code': self.config.get('authorization_code'),
-            'redirect_uri': self.config.get('redirect_uri'),
-            'grant_type': 'authorization_code'
+        payload = {
+            "grant_type": "refresh_token",
+            "refresh_token": self.config.get('refresh_token')
         }
 
         headers = {
@@ -45,7 +44,7 @@ class RingCentralClient:
             '{}/restapi/oauth/token'.format(self.base_url),
             auth=auth,
             headers=headers,
-            data=body)
+            data=payload)
 
         response.raise_for_status()
         json = response.json()

--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -60,7 +60,8 @@ class RingCentralClient:
         if response.status_code == 400 and 'invalid_grant' in response.text:
             LOGGER.error(
                 'Authentication failed: refresh token is probably expired, invalid, revoked or malformed. '
-                'Re-authenticate to obtain a new refresh token and restore access.'
+                'Re-authenticate to obtain a new refresh token and restore access. '
+                f'Response: {response.status_code} - {response.text}'
             )
             raise AuthFailedException('Refresh token expired or invalid – auth failed')
 
@@ -68,7 +69,7 @@ class RingCentralClient:
         data = response.json()
 
         # Rotate refresh_token on every call.
-        # Each new access_token (expires_in: 3600s) invalidates the prior refresh_token.
+        # Each new access_token invalidates the prior refresh_token.
         self.write_config({'refresh_token': data['refresh_token']})
 
         return data['refresh_token'], data['access_token']

--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -31,8 +31,8 @@ class RingCentralClient:
         auth = HTTPBasicAuth(client_id, client_secret)
 
         payload = {
-            "grant_type": "refresh_token",
-            "refresh_token": self.config.get('refresh_token')
+            'refresh_token': self.config.get('refresh_token'),
+            'grant_type': 'refresh_token'
         }
 
         headers = {


### PR DESCRIPTION
# Description of changes
- Authentication call failure fixes

# Manual QA steps
- [x] Discovery: runs
- [x] Sync: runs
- [ ] Unit Tests: not implemented
- [ ] Integration test: not implemented
 
# Note:
- Authentication setup has been moved to via OAuth. The refresh_token expiry is of 7 days.

# Rollback steps
 - revert this branch
