### PR TITLE
Update testing infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-uv
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            uv venv --python=3.9 /usr/local/share/virtualenvs/tap-ringcentral
+            uv venv --python 3.9 /usr/local/share/virtualenvs/tap-ringcentral
             source /usr/local/share/virtualenvs/tap-ringcentral/bin/activate
             uv pip install -U 'pip<19.2' 'setuptools<51.0.0'
             uv pip install .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             uv venv --python=3.9 /usr/local/share/virtualenvs/tap-ringcentral
             source /usr/local/share/virtualenvs/tap-ringcentral/bin/activate
             uv pip install -U 'pip<19.2' 'setuptools<51.0.0'
-            uv pip install .[dev]
+            uv pip install .
       - add_ssh_keys
       - run:
           name: 'JSON Validator'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: 'JSON Validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            stitch-validate-json /usr/local/share/virtualenvs/tap-ringcentral/lib/python3.5/site-packages/tap_ringcentral/schemas/*.json
+            stitch-validate-json /usr/local/share/virtualenvs/tap-ringcentral/lib/python3.9/site-packages/tap_ringcentral/schemas/*.json
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@ jobs:
           command: |
             uv venv --python=3.9 /usr/local/share/virtualenvs/tap-ringcentral
             source /usr/local/share/virtualenvs/tap-ringcentral/bin/activate
-            pip install -U 'pip<19.2' 'setuptools<51.0.0'
-            pip install .[dev]
+            uv pip install -U 'pip<19.2' 'setuptools<51.0.0'
+            uv pip install .[dev]
       - add_ssh_keys
       - run:
           name: 'JSON Validator'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            python3 -mvenv /usr/local/share/virtualenvs/tap-ringcentral
+            uv venv --python=3.9 /usr/local/share/virtualenvs/tap-ringcentral
             source /usr/local/share/virtualenvs/tap-ringcentral/bin/activate
             pip install -U 'pip<19.2' 'setuptools<51.0.0'
             pip install .[dev]


### PR DESCRIPTION
This PR updates the CircleCI config to use `uv` to create and manage virtualenvs and python dependencies