### PR TITLE
SAC-31235: Exlcude un-auth streams from catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,23 @@ jobs:
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json tap_ringcentral/schemas/*.json
       - run:
-          name: 'Unit Tests + Integration Tests'
+          name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-ringcentral/bin/activate
-            python -m unittest discover -s tests -v
+            uv pip install pytest coverage parameterized
+            coverage run -m pytest tests/unittests
+            coverage html
+      - run:
+          name: 'Coverage Report'
+          command: |
+            source /usr/local/share/virtualenvs/tap-ringcentral/bin/activate
+            coverage report -m --fail-under=99
+            coverage html
+      - run:
+          name: 'Integration Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-ringcentral/bin/activate
+            python -m pytest tests --ignore=tests/unittests
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-ringcentral/bin/activate
             uv pip install pytest coverage parameterized
-            coverage run -m pytest tests/unittests
+            coverage run --source=tap_ringcentral -m pytest tests/unittests
             coverage html
       - run:
           name: 'Coverage Report'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.3.0
-  * Exclude un-authorized streams from the catalog.
+  * Exclude un-authorized streams from the catalog [#26](https://github.com/singer-io/tap-ringcentral/pull/26)
 
 ## 1.2.0
   * Bumps singer-python, requests dependency [#25](https://github.com/singer-io/tap-ringcentral/pull/25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.3.0
-  * Exclude un-authorized streams from the catalog [#26](https://github.com/singer-io/tap-ringcentral/pull/26)
+  * Exclude unauthorized streams from the catalog [#26](https://github.com/singer-io/tap-ringcentral/pull/26)
 
 ## 1.2.0
   * Bumps singer-python, requests dependency [#25](https://github.com/singer-io/tap-ringcentral/pull/25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## 1.2.1
-  * Bump requests version to 2.34.2 to address security vulnerability [#27](https://github.com/singer-io/tap-ringcentral/pull/27)
-
 ## 1.3.0
   * Exclude unauthorized streams from the catalog [#26](https://github.com/singer-io/tap-ringcentral/pull/26)
+
+## 1.2.1
+  * Bump requests version to 2.34.2 to address security vulnerability [#27](https://github.com/singer-io/tap-ringcentral/pull/27)
 
 ## 1.2.0
   * Bumps singer-python, requests dependency [#25](https://github.com/singer-io/tap-ringcentral/pull/25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.0
+  * Exclude un-authorized streams from the catalog.
+
 ## 1.2.0
   * Bumps singer-python, requests dependency [#25](https://github.com/singer-io/tap-ringcentral/pull/25)
 ## 1.1.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-ringcentral',
-      version='1.2.0',
+      version='1.3.0',
       description='Singer.io tap for extracting data from the RingCentral API',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',

--- a/tap_ringcentral/__init__.py
+++ b/tap_ringcentral/__init__.py
@@ -30,7 +30,7 @@ class RingCentralRunner:
 
     def do_discover(self):
         LOGGER.info("Starting discovery")
-        catalog = discover()
+        catalog = discover(self.client)
         json.dump(catalog.to_dict(), sys.stdout, indent=2)
         LOGGER.info("Finished discover")
 

--- a/tap_ringcentral/client.py
+++ b/tap_ringcentral/client.py
@@ -20,6 +20,12 @@ class AuthFailedException(APIException):
     pass
 
 
+class RingCentralForbiddenError(Exception):
+    """Raised when the RingCentral API returns HTTP 403 Forbidden,
+    indicating that the credentials lack read access to a resource."""
+    pass
+
+
 class RingCentralClient:
 
     MAX_TRIES = 7
@@ -98,7 +104,12 @@ class RingCentralClient:
             time.sleep(int(timeout))
             raise APIException("Rate limit exceeded")
 
-        elif response.status_code in [401, 403]:
+        elif response.status_code == 403:
+            raise RingCentralForbiddenError(
+                "HTTP-error-code: 403, Error: {}".format(response.text)
+            )
+
+        elif response.status_code == 401:
             # Unauthorized - has the token expired?
             self.refresh_token, self.access_token = self.get_authorization()
             raise APIException("Token expired - refetching")

--- a/tap_ringcentral/discover.py
+++ b/tap_ringcentral/discover.py
@@ -64,7 +64,7 @@ def discover(client=None) -> Catalog:
     that cannot be read are excluded from the returned catalog.
     """
     schemas, field_metadata = get_schemas()
-    if client:  # Added client check since mock-integration tests are tightly dependent on discover call w/o client
+    if client is not None:  # Added client check since mock-integration tests are tightly dependent on discover call w/o client
         _apply_access_checks(client, schemas, field_metadata)
 
     catalog = Catalog([])

--- a/tap_ringcentral/discover.py
+++ b/tap_ringcentral/discover.py
@@ -52,7 +52,7 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
         )
     if inaccessible_streams:
         LOGGER.warning(
-            "No 'read' access to stream(s): %s. Excluded from catalog.",
+            "Unauthorized streams excluded from catalog: %s",
             ", ".join(inaccessible_streams),
         )
 

--- a/tap_ringcentral/discover.py
+++ b/tap_ringcentral/discover.py
@@ -2,15 +2,71 @@ import singer
 from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 
+from tap_ringcentral.client import RingCentralForbiddenError
 from tap_ringcentral.schema import get_schemas
+from tap_ringcentral.streams import AVAILABLE_STREAMS
 
 LOGGER = singer.get_logger()
 
 
-def discover() -> Catalog:
-    """Run the discovery mode, prepare the catalog file and return the
-    catalog."""
+def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
+    """
+    Remove child streams from the catalog whose parent stream was excluded.
+    Mutates schemas and field_metadata in place.
+    """
+    for name, stream_cls in list(AVAILABLE_STREAMS.items()):
+        parent = getattr(stream_cls, "parent", None)
+        if name in schemas and parent and parent not in schemas:
+            LOGGER.warning(
+                "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                name,
+                parent,
+            )
+            schemas.pop(name, None)
+            field_metadata.pop(name, None)
+
+
+def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
+    """
+    Probe each stream for read access and remove inaccessible streams
+    (and their children) from schemas and field_metadata in place.
+    Raises RingCentralForbiddenError if no streams are accessible.
+    """
+
+    inaccessible_streams = [
+        stream_name
+        for stream_name, stream_obj in AVAILABLE_STREAMS.items()
+        if stream_name in schemas
+        and not stream_obj(client=client).check_access()
+    ]
+
+    for stream_name in inaccessible_streams:
+        schemas.pop(stream_name, None)
+        field_metadata.pop(stream_name, None)
+
+    _prune_inaccessible_children(schemas, field_metadata)
+
+    if not schemas:
+        raise RingCentralForbiddenError(
+            "HTTP-error-code: 403, Error: The credentials do not have 'read' access to any supported streams. Please re-check configuration."
+        )
+    if inaccessible_streams:
+        LOGGER.warning(
+            "No 'read' access to stream(s): %s. Excluded from catalog.",
+            ", ".join(inaccessible_streams),
+        )
+
+
+def discover(client=None) -> Catalog:
+    """Run discovery and return a catalog.
+
+    Access to each stream is verified when a client is provided; streams
+    that cannot be read are excluded from the returned catalog.
+    """
     schemas, field_metadata = get_schemas()
+    if client:  # Added client check since mock-integration tests are tightly dependent on discover call w/o client
+        _apply_access_checks(client, schemas, field_metadata)
+
     catalog = Catalog([])
     for stream_name, schema_dict in schemas.items():
         try:

--- a/tap_ringcentral/streams/base.py
+++ b/tap_ringcentral/streams/base.py
@@ -90,7 +90,7 @@ class BaseStream:
             )
             return False
 
-    def get_stream_data(self, result, contact_id):
+    def get_stream_data(self, result, contact_id=None):
         xf = []
         for record in result['records']:
             record_xf = self.transform_record(record)
@@ -195,7 +195,7 @@ class ContactBaseStream(BaseStream):
             "showDeleted": True,
         }
 
-    def get_stream_data(self, result, contact_id):
+    def get_stream_data(self, result, contact_id=None):
         xf = []
         for record in result['records']:
             record_xf = self.transform_record(record)

--- a/tap_ringcentral/streams/base.py
+++ b/tap_ringcentral/streams/base.py
@@ -73,8 +73,10 @@ class BaseStream:
         # Replace any {placeholder} (e.g. {extensionId}) with '~' for the probe
         url = re.sub(r'\{[^}]+\}', '~', url_template)
 
+        params = self.params if hasattr(self, 'params') else {"page": 1, "perPage": 1}
+
         try:
-            self.client.make_request(url, self.API_METHOD, params={"page": 1, "perPage": 1})
+            self.client.make_request(url, self.API_METHOD, params=params)
             return True
         except RingCentralForbiddenError as exc:
             LOGGER.warning(
@@ -151,6 +153,7 @@ class BaseStream:
 
         return self.state
 
+
 class ContactBaseStream(BaseStream):
     KEY_PROPERTIES = ['id']
 
@@ -199,42 +202,50 @@ class ContactBaseStream(BaseStream):
     def sync_data_for_extension(self, date, interval, extensionId):
         table = self.TABLE
 
-        page = 1
-        per_page = 100
+        try:
+            page = 1
+            per_page = 100
 
-        date_from = date.isoformat()
-        date_to = (date + interval).isoformat()
+            date_from = date.isoformat()
+            date_to = (date + interval).isoformat()
 
-        while True:
-            LOGGER.info('Syncing {} for contact={} from {} to {}, page={}'.format(
+            while True:
+                LOGGER.info('Syncing {} for contact={} from {} to {}, page={}'.format(
+                    table,
+                    extensionId,
+                    date_from,
+                    date_to,
+                    page
+                ))
+
+                params = self.get_params(date_from, date_to, page, per_page)
+                body = self.get_body()
+
+                url = "{}{}".format(
+                    self.client.base_url,
+                    self.api_path.format(extensionId=extensionId)
+                )
+
+                # The API rate limits us pretty aggressively
+                time.sleep(5)
+
+                result = self.client.make_request(
+                    url, self.API_METHOD, params=params, body=body)
+
+                data = self.get_stream_data(result, extensionId)
+
+                with singer.metrics.record_counter(endpoint=table) as counter:
+                    singer.write_records(table, data)
+                    counter.increment(len(data))
+
+                if len(data) < per_page:
+                    break
+
+                page += 1
+        except RingCentralForbiddenError as e:
+            LOGGER.warning(
+                "Permission denied for stream '%s' on extension '%s': %s. Skipping this extension.",
                 table,
                 extensionId,
-                date_from,
-                date_to,
-                page
-            ))
-
-            params = self.get_params(date_from, date_to, page, per_page)
-            body = self.get_body()
-
-            url = "{}{}".format(
-                self.client.base_url,
-                self.api_path.format(extensionId=extensionId)
+                str(e)
             )
-
-            # The API rate limits us pretty aggressively
-            time.sleep(5)
-
-            result = self.client.make_request(
-                url, self.API_METHOD, params=params, body=body)
-
-            data = self.get_stream_data(result, extensionId)
-
-            with singer.metrics.record_counter(endpoint=table) as counter:
-                singer.write_records(table, data)
-                counter.increment(len(data))
-
-            if len(data) < per_page:
-                break
-
-            page += 1

--- a/tap_ringcentral/streams/base.py
+++ b/tap_ringcentral/streams/base.py
@@ -7,6 +7,7 @@ import singer
 import singer.utils
 import singer.metrics
 import time
+from typing import ClassVar, Optional
 
 from datetime import timedelta, datetime
 
@@ -23,9 +24,12 @@ LOGGER = singer.get_logger()
 
 class BaseStream:
     KEY_PROPERTIES = ['id']
-    TABLE = None
-    REQUIRES = []
-    parent = None
+    TABLE: Optional[str] = None
+    REQUIRES: ClassVar[list] = []
+    parent: Optional[str] = None
+    # Subclasses should override these attributes
+    api_path: str
+    API_METHOD: ClassVar[str]
 
     def __init__(self, config=None, state=None, catalog=None, client=None):
         self.config = config
@@ -57,7 +61,7 @@ class BaseStream:
         return {}
 
     def get_url(self, path):
-        return '{}{}'.format(BASE_URL, path)
+        return '{}{}'.format(self.client.base_url, path)
 
     def check_access(self) -> bool:
         """
@@ -80,9 +84,9 @@ class BaseStream:
             return True
         except RingCentralForbiddenError as exc:
             LOGGER.warning(
-                "Permission Error: Stream '%s' - %s",
+                "Unauthorized Stream: %s, excluding from catalog. HTTP-Error-Message: '%s'",
                 self.__class__.__name__,
-                exc,
+                str(exc)
             )
             return False
 

--- a/tap_ringcentral/streams/base.py
+++ b/tap_ringcentral/streams/base.py
@@ -1,6 +1,7 @@
 import inspect
 import math
 import os
+import re
 import pytz
 import singer
 import singer.utils
@@ -11,6 +12,7 @@ from datetime import timedelta, datetime
 
 import tap_ringcentral.cache
 from tap_ringcentral.config import get_config_start_date
+from tap_ringcentral.client import RingCentralForbiddenError
 from tap_ringcentral.state import incorporate, save_state, \
     get_last_record_value_for_table
 
@@ -23,8 +25,9 @@ class BaseStream:
     KEY_PROPERTIES = ['id']
     TABLE = None
     REQUIRES = []
+    parent = None
 
-    def __init__(self, config, state, catalog, client):
+    def __init__(self, config=None, state=None, catalog=None, client=None):
         self.config = config
         self.state = state
         self.catalog = catalog
@@ -55,6 +58,31 @@ class BaseStream:
 
     def get_url(self, path):
         return '{}{}'.format(BASE_URL, path)
+
+    def check_access(self) -> bool:
+        """
+        Verify that the API credentials have read access to this stream.
+        Returns True if accessible, False if a 403 Forbidden error is raised.
+        Child streams (where parent is set) always return True; their
+        removal from the catalog is handled by _prune_inaccessible_children.
+        """
+        if self.parent:
+            return True
+
+        url_template = "{}{}".format(self.client.base_url, self.api_path)
+        # Replace any {placeholder} (e.g. {extensionId}) with '~' for the probe
+        url = re.sub(r'\{[^}]+\}', '~', url_template)
+
+        try:
+            self.client.make_request(url, self.API_METHOD, params={"page": 1, "perPage": 1})
+            return True
+        except RingCentralForbiddenError as exc:
+            LOGGER.warning(
+                "Permission Error: Stream '%s' - %s",
+                self.__class__.__name__,
+                exc,
+            )
+            return False
 
     def get_stream_data(self, result, contact_id):
         xf = []

--- a/tap_ringcentral/streams/messages.py
+++ b/tap_ringcentral/streams/messages.py
@@ -11,6 +11,7 @@ class MessageStream(ContactBaseStream):
     KEY_PROPERTIES = ['id']
     API_METHOD = 'GET'
     TABLE = 'messages'
+    params = {'page': 1, 'perPage': 100, 'showDeleted': True}
 
     @property
     def api_path(self):

--- a/tests/unittests/test_base_stream_methods.py
+++ b/tests/unittests/test_base_stream_methods.py
@@ -1,0 +1,77 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from tap_ringcentral.streams.base import BaseStream
+
+
+class TestBaseStreamGetUrl(unittest.TestCase):
+    """
+    Unit tests for BaseStream.get_url method.
+    """
+
+    def setUp(self):
+        """Set up common test configuration before each test case runs."""
+        self.config = {
+            "client_id": "test",
+            "client_secret": "test",
+            "refresh_token": "test",
+            "api_url": "https://platform.ringcentral.com",
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+        self.mock_catalog = MagicMock()
+        self.mock_catalog.metadata = None
+        self.mock_client = MagicMock()
+
+    def test_get_url_constructs_url(self):
+        """Test get_url combines BASE_URL with path."""
+        stream = BaseStream(self.config, {}, self.mock_catalog, self.mock_client)
+
+        # The get_url method uses BASE_URL from the module, verify it exists
+        # This is a simple test that just exercises the method
+        path = "/test/path"
+
+        # get_url uses BASE_URL which should be defined in base.py
+        # This test documents that the method exists and can be called
+        try:
+            result = stream.get_url(path)
+            # If BASE_URL is defined, result should contain the path
+            self.assertIn("test/path", result)
+        except NameError:
+            # BASE_URL might not be defined in all contexts
+            pass
+
+
+class TestBaseStreamLoadSchemaByName(unittest.TestCase):
+    """
+    Unit tests for BaseStream.load_schema_by_name method.
+    """
+
+    def setUp(self):
+        """Set up common test configuration before each test case runs."""
+        self.config = {
+            "client_id": "test",
+            "client_secret": "test",
+            "refresh_token": "test",
+            "api_url": "https://platform.ringcentral.com",
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+        self.mock_catalog = MagicMock()
+        self.mock_catalog.metadata = None
+        self.mock_client = MagicMock()
+
+    @patch("tap_ringcentral.streams.base.singer.utils.load_json")
+    def test_load_schema_by_name(self, mock_load_json):
+        """Test load_schema_by_name loads JSON from schemas directory."""
+        mock_load_json.return_value = {"type": "object", "properties": {}}
+
+        stream = BaseStream(self.config, {}, self.mock_catalog, self.mock_client)
+
+        result = stream.load_schema_by_name("contacts")
+
+        self.assertEqual(result, {"type": "object", "properties": {}})
+        mock_load_json.assert_called_once()
+
+        # Verify the path includes schemas directory
+        call_args = mock_load_json.call_args
+        path_arg = call_args[0][0]
+        self.assertIn("schemas", path_arg)
+        self.assertIn("contacts.json", path_arg)

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 import requests
 from tap_ringcentral.client import RingCentralClient, APIException, AuthFailedException
+from tap_ringcentral.client import RingCentralForbiddenError
 
 
 class MockResponse:
@@ -218,24 +219,21 @@ class TestMakeRequest(unittest.TestCase):
         # Verify request was called 3 times (initial API + auth refresh + retry)
         self.assertEqual(mock_request.call_count, 3)
 
-    def test_forbidden_error_triggers_token_refresh(self, mock_request, mock_json_dump, mock_open):
-        """Test case for 403 Forbidden error triggers token refresh and successful retry."""
+    def test_forbidden_error_raises_forbidden_error(self, mock_request, mock_json_dump, mock_open):
+        """Test case for 403 Forbidden error raises RingCentralForbiddenError immediately
+        (no token refresh, no retry — 403 signals a permissions issue, not auth expiry)."""
         client = self._create_client(mock_request)
 
         mock_response_403 = MagicMock()
         mock_response_403.status_code = 403
         mock_response_403.text = "Forbidden"
 
-        mock_request.side_effect = [
-            mock_response_403,  # make_request API call returns 403
-            self.auth_response,  # get_authorization refresh call
-            get_response(200, json={"records": ["retried"]}),  # retry succeeds after token refresh
-        ]
+        mock_request.return_value = mock_response_403
 
-        result = client.make_request(self.url, self.method)
-        self.assertEqual(result, {"records": ["retried"]})
-        # Verify request was called 3 times (initial API + auth refresh + retry)
-        self.assertEqual(mock_request.call_count, 3)
+        with self.assertRaises(RingCentralForbiddenError):
+            client.make_request(self.url, self.method)
+        # Only the single API call — no token-refresh or retry
+        self.assertEqual(mock_request.call_count, 1)
 
     def test_other_error_status_raises_api_exception(self, mock_request, mock_json_dump, mock_open):
         """Test case for non-200/429/401/403 error status raises APIException."""

--- a/tests/unittests/test_config.py
+++ b/tests/unittests/test_config.py
@@ -1,0 +1,37 @@
+import unittest
+from tap_ringcentral.config import get_config_start_date
+from dateutil.parser import parse
+
+
+class TestGetConfigStartDate(unittest.TestCase):
+    """
+    Unit tests for the get_config_start_date function in tap_ringcentral/config.py
+    """
+
+    def test_get_config_start_date_with_iso_string(self):
+        """Test that get_config_start_date parses ISO format strings."""
+        config = {"start_date": "2025-01-15T00:00:00Z"}
+        result = get_config_start_date(config)
+        expected = parse("2025-01-15T00:00:00Z")
+        self.assertEqual(result, expected)
+
+    def test_get_config_start_date_with_different_format(self):
+        """Test that get_config_start_date can parse various date formats."""
+        config = {"start_date": "2025-01-15"}
+        result = get_config_start_date(config)
+        # Should parse without error
+        self.assertIsNotNone(result)
+
+    def test_get_config_start_date_returns_datetime_object(self):
+        """Test that get_config_start_date returns a datetime object."""
+        config = {"start_date": "2025-01-15T00:00:00Z"}
+        result = get_config_start_date(config)
+        self.assertTrue(hasattr(result, 'year'))
+        self.assertTrue(hasattr(result, 'month'))
+        self.assertTrue(hasattr(result, 'day'))
+
+    def test_get_config_start_date_with_timezone(self):
+        """Test that get_config_start_date preserves timezone info."""
+        config = {"start_date": "2025-01-15T12:30:00-05:00"}
+        result = get_config_start_date(config)
+        self.assertIsNotNone(result.tzinfo)

--- a/tests/unittests/test_contact_base_stream_contacts.py
+++ b/tests/unittests/test_contact_base_stream_contacts.py
@@ -1,0 +1,53 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from datetime import datetime, timedelta
+import pytz
+
+from tap_ringcentral.streams.base import ContactBaseStream
+
+
+class TestContactBaseStreamSyncDataForPeriodWithContacts(unittest.TestCase):
+    """
+    Unit tests for ContactBaseStream.sync_data_for_period when contacts cache is populated.
+    """
+
+    def setUp(self):
+        """Set up common test configuration before each test case runs."""
+        self.config = {
+            "client_id": "test",
+            "client_secret": "test",
+            "refresh_token": "test",
+            "api_url": "https://platform.ringcentral.com",
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+        self.state = {}
+        self.mock_catalog = MagicMock()
+        self.mock_catalog.metadata = None
+        self.mock_client = MagicMock()
+
+    @patch("tap_ringcentral.streams.base.tap_ringcentral.cache.contacts")
+    def test_sync_data_for_period_iterates_contacts(self, mock_cache_contacts):
+        """Test sync_data_for_period iterates through cached contacts."""
+        stream = ContactBaseStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        stream.TABLE = "call_log"
+
+        # Mock cache with multiple contacts
+        mock_cache_contacts.__iter__ = MagicMock(return_value=iter([
+            {"id": "ext1"},
+            {"id": "ext2"},
+        ]))
+
+        stream.sync_data_for_extension = MagicMock()
+
+        date = datetime(2025, 1, 1, tzinfo=pytz.utc)
+        interval = timedelta(days=7)
+
+        stream.sync_data_for_period(date, interval)
+
+        # Verify sync_data_for_extension was called for each contact
+        self.assertEqual(stream.sync_data_for_extension.call_count, 2)
+
+        # Verify it was called with correct extensionIds
+        calls = stream.sync_data_for_extension.call_args_list
+        self.assertEqual(calls[0][0][2], "ext1")
+        self.assertEqual(calls[1][0][2], "ext2")

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,112 +1,235 @@
 import unittest
 from unittest.mock import patch, MagicMock
 from singer.catalog import Catalog
-from tap_ringcentral.discover import discover
+from tap_ringcentral.discover import discover, _apply_access_checks, _prune_inaccessible_children
+from tap_ringcentral.client import RingCentralForbiddenError
 
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_schemas(*stream_names):
+    return {
+        name: {"type": "object", "properties": {"id": {"type": "string"}}}
+        for name in stream_names
+    }
+
+
+def _make_metadata(*stream_names):
+    return {
+        name: [{"breadcrumb": (), "metadata": {"table-key-properties": ["id"]}}]
+        for name in stream_names
+    }
+
+
+ALL_STREAMS = ["contacts", "call_log", "company_call_log", "messages"]
+
+
+# ---------------------------------------------------------------------------
+# TestDiscover
+# ---------------------------------------------------------------------------
 
 class TestDiscover(unittest.TestCase):
-    """
-    Unit tests for the `discover` function in the tap_ringcentral.discover module.
+    """Unit tests for the `discover` function."""
 
-    This test class verifies that:
-      - The discover function returns a valid Catalog object.
-      - All expected streams are present in the catalog.
-      - Each stream has the correct key properties and metadata.
-    """
-
+    @patch("tap_ringcentral.discover._apply_access_checks")
     @patch("tap_ringcentral.discover.get_schemas")
-    def test_discover_returns_catalog(self, mock_get_schemas):
-        """Test that discover returns a Catalog instance."""
+    def test_discover_returns_catalog(self, mock_get_schemas, _mock_access):
+        """discover(client) returns a Catalog instance."""
         mock_get_schemas.return_value = (
-            {
-                "contacts": {
-                    "type": "object",
-                    "properties": {"id": {"type": "string"}}
-                }
-            },
-            {
-                "contacts": [
-                    {"breadcrumb": (), "metadata": {"table-key-properties": ["id"]}}
-                ]
-            },
+            _make_schemas("contacts"),
+            _make_metadata("contacts"),
         )
-
-        catalog = discover()
+        catalog = discover(MagicMock())
         self.assertIsInstance(catalog, Catalog)
 
+    @patch("tap_ringcentral.discover._apply_access_checks")
     @patch("tap_ringcentral.discover.get_schemas")
-    def test_discover_has_expected_streams(self, mock_get_schemas):
-        """Test that discover returns all expected streams."""
-        schemas = {}
-        field_metadata = {}
-        for stream_name in ["contacts", "call_log", "company_call_log", "messages"]:
-            schemas[stream_name] = {
-                "type": "object",
-                "properties": {"id": {"type": "string"}}
-            }
-            field_metadata[stream_name] = [
-                {"breadcrumb": (), "metadata": {"table-key-properties": ["id"]}}
-            ]
-
-        mock_get_schemas.return_value = (schemas, field_metadata)
-
-        catalog = discover()
+    def test_discover_has_expected_streams(self, mock_get_schemas, _mock_access):
+        """discover(client) returns all four expected streams."""
+        mock_get_schemas.return_value = (
+            _make_schemas(*ALL_STREAMS),
+            _make_metadata(*ALL_STREAMS),
+        )
+        catalog = discover(MagicMock())
         stream_names = [entry.stream for entry in catalog.streams]
-
-        self.assertIn("contacts", stream_names)
-        self.assertIn("call_log", stream_names)
-        self.assertIn("company_call_log", stream_names)
-        self.assertIn("messages", stream_names)
+        for name in ALL_STREAMS:
+            self.assertIn(name, stream_names)
         self.assertEqual(len(catalog.streams), 4)
 
+    @patch("tap_ringcentral.discover._apply_access_checks")
     @patch("tap_ringcentral.discover.get_schemas")
-    def test_discover_stream_has_key_properties(self, mock_get_schemas):
-        """Test that each discovered stream has the correct key properties."""
+    def test_discover_stream_has_key_properties(self, mock_get_schemas, _mock_access):
+        """Each stream entry carries the correct key_properties."""
         mock_get_schemas.return_value = (
-            {
-                "contacts": {
-                    "type": "object",
-                    "properties": {"id": {"type": "string"}}
-                }
-            },
-            {
-                "contacts": [
-                    {"breadcrumb": (), "metadata": {"table-key-properties": ["id"]}}
-                ]
-            },
+            _make_schemas("contacts"),
+            _make_metadata("contacts"),
         )
+        catalog = discover(MagicMock())
+        self.assertEqual(catalog.streams[0].key_properties, ["id"])
 
-        catalog = discover()
-        contacts_entry = catalog.streams[0]
-        self.assertEqual(contacts_entry.key_properties, ["id"])
+    @patch("tap_ringcentral.discover._apply_access_checks")
+    @patch("tap_ringcentral.discover.get_schemas")
+    def test_discover_with_client_calls_access_checks(
+        self, mock_get_schemas, mock_apply_access
+    ):
+        """When a client is supplied, _apply_access_checks is called."""
+        mock_get_schemas.return_value = (
+            _make_schemas(*ALL_STREAMS),
+            _make_metadata(*ALL_STREAMS),
+        )
+        mock_client = MagicMock()
+        discover(mock_client)
+        mock_apply_access.assert_called_once()
+        args = mock_apply_access.call_args[0]
+        self.assertIs(args[0], mock_client)
 
+
+# ---------------------------------------------------------------------------
+# TestApplyAccessChecks
+# ---------------------------------------------------------------------------
+
+class TestApplyAccessChecks(unittest.TestCase):
+    """Unit tests for _apply_access_checks."""
+
+    def _stream_mock(self, accessible):
+        """Return a stream-class mock whose instantiation returns a check_access stub."""
+        instance = MagicMock()
+        instance.check_access.return_value = accessible
+        cls = MagicMock(return_value=instance)
+        cls.parent = None
+        return cls
+
+    @patch("tap_ringcentral.discover.AVAILABLE_STREAMS")
+    def test_all_streams_accessible_catalog_unchanged(self, mock_streams):
+        """When every stream is accessible, schemas and metadata are untouched."""
+        mock_streams.__iter__ = lambda _: iter(ALL_STREAMS)
+        mock_streams.items.return_value = [
+            (n, self._stream_mock(True)) for n in ALL_STREAMS
+        ]
+        schemas = _make_schemas(*ALL_STREAMS)
+        metadata = _make_metadata(*ALL_STREAMS)
+        _apply_access_checks(MagicMock(), schemas, metadata)
+        self.assertEqual(set(schemas.keys()), set(ALL_STREAMS))
+
+    @patch("tap_ringcentral.discover.AVAILABLE_STREAMS")
+    def test_inaccessible_stream_removed_from_catalog(self, mock_streams):
+        """A stream returning check_access=False is removed from schemas/metadata."""
+        stream_mocks = {
+            "contacts": self._stream_mock(True),
+            "call_log": self._stream_mock(False),
+            "company_call_log": self._stream_mock(True),
+            "messages": self._stream_mock(True),
+        }
+        mock_streams.items.return_value = list(stream_mocks.items())
+        schemas = _make_schemas(*ALL_STREAMS)
+        metadata = _make_metadata(*ALL_STREAMS)
+
+        _apply_access_checks(MagicMock(), schemas, metadata)
+
+        self.assertNotIn("call_log", schemas)
+        self.assertNotIn("call_log", metadata)
+        for name in ["contacts", "company_call_log", "messages"]:
+            self.assertIn(name, schemas)
+
+    @patch("tap_ringcentral.discover.AVAILABLE_STREAMS")
+    def test_all_inaccessible_raises_forbidden_error(self, mock_streams):
+        """When every stream is inaccessible, RingCentralForbiddenError is raised."""
+        mock_streams.items.return_value = [
+            (n, self._stream_mock(False)) for n in ALL_STREAMS
+        ]
+        schemas = _make_schemas(*ALL_STREAMS)
+        metadata = _make_metadata(*ALL_STREAMS)
+
+        with self.assertRaises(RingCentralForbiddenError):
+            _apply_access_checks(MagicMock(), schemas, metadata)
+
+
+# ---------------------------------------------------------------------------
+# TestPruneInaccessibleChildren
+# ---------------------------------------------------------------------------
+
+class TestPruneInaccessibleChildren(unittest.TestCase):
+    """Unit tests for _prune_inaccessible_children."""
+
+    @patch("tap_ringcentral.discover.AVAILABLE_STREAMS")
+    def test_child_pruned_when_parent_missing(self, mock_streams):
+        """A child stream is removed when its parent is absent from schemas."""
+        parent_cls = MagicMock()
+        parent_cls.parent = None
+        child_cls = MagicMock()
+        child_cls.parent = "parent_stream"
+
+        mock_streams.items.return_value = [
+            ("parent_stream", parent_cls),
+            ("child_stream", child_cls),
+        ]
+
+        schemas = {"child_stream": {}}          # parent already removed
+        metadata = {"child_stream": []}
+
+        _prune_inaccessible_children(schemas, metadata)
+
+        self.assertNotIn("child_stream", schemas)
+        self.assertNotIn("child_stream", metadata)
+
+    @patch("tap_ringcentral.discover.AVAILABLE_STREAMS")
+    def test_child_kept_when_parent_present(self, mock_streams):
+        """A child stream is retained when its parent remains in schemas."""
+        parent_cls = MagicMock()
+        parent_cls.parent = None
+        child_cls = MagicMock()
+        child_cls.parent = "parent_stream"
+
+        mock_streams.items.return_value = [
+            ("parent_stream", parent_cls),
+            ("child_stream", child_cls),
+        ]
+
+        schemas = {"parent_stream": {}, "child_stream": {}}
+        metadata = {"parent_stream": [], "child_stream": []}
+
+        _prune_inaccessible_children(schemas, metadata)
+
+        self.assertIn("parent_stream", schemas)
+        self.assertIn("child_stream", schemas)
+
+    @patch("tap_ringcentral.discover.AVAILABLE_STREAMS")
+    def test_no_parent_streams_at_all(self, mock_streams):
+        """All independent streams (parent=None) are retained unchanged."""
+        cls_a = MagicMock()
+        cls_a.parent = None
+        cls_b = MagicMock()
+        cls_b.parent = None
+
+        mock_streams.items.return_value = [("a", cls_a), ("b", cls_b)]
+        schemas = {"a": {}, "b": {}}
+        metadata = {"a": [], "b": []}
+
+        _prune_inaccessible_children(schemas, metadata)
+
+        self.assertEqual(set(schemas.keys()), {"a", "b"})
+
+
+# ---------------------------------------------------------------------------
+# TestGetSchemas
+# ---------------------------------------------------------------------------
 
 class TestGetSchemas(unittest.TestCase):
-    """
-    Unit tests for the `get_schemas` function in the tap_ringcentral.schema module.
-
-    This test class verifies that:
-      - Schemas are loaded for all available streams.
-      - Field metadata is populated correctly.
-    """
+    """Unit tests for `get_schemas`."""
 
     @patch("tap_ringcentral.schema.open", create=True)
     @patch("tap_ringcentral.schema.json.load")
     def test_get_schemas_returns_all_streams(self, mock_json_load, mock_open):
-        """Test that get_schemas returns schemas for all available streams."""
+        """get_schemas returns schemas for all available streams."""
         mock_json_load.return_value = {
             "type": "object",
-            "properties": {"id": {"type": "string"}}
+            "properties": {"id": {"type": "string"}},
         }
 
         from tap_ringcentral.schema import get_schemas
         schemas, field_metadata = get_schemas()
-
-        expected_streams = ["contacts", "call_log", "company_call_log", "messages"]
-        for stream_name in expected_streams:
-            self.assertIn(stream_name, schemas)
-            self.assertIn(stream_name, field_metadata)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        for name in ALL_STREAMS:
+            self.assertIn(name, schemas)
+            self.assertIn(name, field_metadata)

--- a/tests/unittests/test_discover_error.py
+++ b/tests/unittests/test_discover_error.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from tap_ringcentral.discover import discover
+from singer.catalog import Catalog
+
+
+class TestDiscoverSchemaException(unittest.TestCase):
+    """
+    Unit tests for discover function error handling when schema is invalid.
+    """
+
+    @patch("tap_ringcentral.discover.get_schemas")
+    def test_discover_schema_exception_handling(self, mock_get_schemas):
+        """Test discover raises and logs exception when schema is invalid."""
+        # Simulate a bad schema dict
+        mock_get_schemas.return_value = (
+            {"contacts": None},  # Invalid schema (None instead of dict)
+            {"contacts": [{"breadcrumb": [], "metadata": {"table-key-properties": ["id"]}}]}
+        )
+
+        with self.assertRaises(Exception):
+            discover(client=None)
+
+
+class TestDiscoverMultipleStreams(unittest.TestCase):
+    """
+    Unit tests for discover function with multiple streams.
+    """
+
+    @patch("tap_ringcentral.discover.get_schemas")
+    def test_discover_returns_all_streams(self, mock_get_schemas):
+        """Test discover returns all available streams in catalog."""
+        mock_get_schemas.return_value = (
+            {
+                "contacts": {"type": "object", "properties": {}},
+                "call_log": {"type": "object", "properties": {}},
+                "messages": {"type": "object", "properties": {}},
+            },
+            {
+                "contacts": [{"breadcrumb": [], "metadata": {"table-key-properties": ["id"]}}],
+                "call_log": [{"breadcrumb": [], "metadata": {"table-key-properties": ["id"]}}],
+                "messages": [{"breadcrumb": [], "metadata": {"table-key-properties": ["id"]}}],
+            }
+        )
+
+        catalog = discover(client=None)
+
+        self.assertEqual(len(catalog.streams), 3)
+        stream_names = {s.stream for s in catalog.streams}
+        self.assertEqual(stream_names, {"contacts", "call_log", "messages"})

--- a/tests/unittests/test_discover_extra.py
+++ b/tests/unittests/test_discover_extra.py
@@ -1,0 +1,207 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from tap_ringcentral.discover import discover, _apply_access_checks, _prune_inaccessible_children
+from tap_ringcentral.client import RingCentralForbiddenError
+
+
+class TestDiscover(unittest.TestCase):
+    """
+    Unit tests for the discover function.
+    """
+
+    @patch("tap_ringcentral.discover.get_schemas")
+    def test_discover_without_client(self, mock_get_schemas):
+        """Test discover without client does not perform access checks."""
+        mock_get_schemas.return_value = (
+            {"contacts": {"type": "object", "properties": {}}},
+            {"contacts": [{"breadcrumb": [], "metadata": {"table-key-properties": ["id"]}}]}
+        )
+
+        catalog = discover(client=None)
+
+        self.assertEqual(len(catalog.streams), 1)
+        self.assertEqual(catalog.streams[0].stream, "contacts")
+        mock_get_schemas.assert_called_once()
+
+    @patch("tap_ringcentral.discover._apply_access_checks")
+    @patch("tap_ringcentral.discover.get_schemas")
+    def test_discover_with_client_applies_access_checks(self, mock_get_schemas, mock_apply_checks):
+        """Test discover with client calls access checks."""
+        mock_get_schemas.return_value = (
+            {"contacts": {"type": "object", "properties": {}}},
+            {"contacts": [{"breadcrumb": [], "metadata": {"table-key-properties": ["id"]}}]}
+        )
+        mock_client = MagicMock()
+
+        catalog = discover(client=mock_client)
+
+        mock_apply_checks.assert_called_once()
+        self.assertEqual(len(catalog.streams), 1)
+
+    @patch("tap_ringcentral.discover.get_schemas")
+    def test_discover_returns_catalog_with_correct_properties(self, mock_get_schemas):
+        """Test discover returns catalog with correct stream properties."""
+        mock_get_schemas.return_value = (
+            {
+                "contacts": {
+                    "type": "object",
+                    "properties": {"id": {"type": "string"}, "name": {"type": "string"}}
+                }
+            },
+            {
+                "contacts": [
+                    {"breadcrumb": [], "metadata": {"table-key-properties": ["id"]}}
+                ]
+            }
+        )
+
+        catalog = discover(client=None)
+
+        self.assertEqual(len(catalog.streams), 1)
+        stream = catalog.streams[0]
+        self.assertEqual(stream.stream, "contacts")
+        self.assertEqual(stream.tap_stream_id, "contacts")
+        self.assertEqual(stream.key_properties, ["id"])
+
+
+class TestApplyAccessChecks(unittest.TestCase):
+    """
+    Unit tests for the _apply_access_checks function.
+    """
+
+    @patch("tap_ringcentral.discover.AVAILABLE_STREAMS")
+    def test_all_streams_accessible_catalog_unchanged(self, mock_available_streams):
+        """Test _apply_access_checks does not modify catalog when all streams are accessible."""
+        mock_stream_class = MagicMock()
+        # Ensure the mock class doesn't have a parent attribute
+        del mock_stream_class.parent
+
+        mock_stream_instance = MagicMock()
+        mock_stream_instance.check_access.return_value = True
+        mock_stream_class.return_value = mock_stream_instance
+
+        mock_available_streams.items.return_value = [("contacts", mock_stream_class)]
+
+        schemas = {"contacts": {}}
+        field_metadata = {"contacts": []}
+
+        mock_client = MagicMock()
+
+        # Should not raise any exception
+        _apply_access_checks(mock_client, schemas, field_metadata)
+
+        self.assertIn("contacts", schemas)
+        self.assertIn("contacts", field_metadata)
+
+    @patch("tap_ringcentral.discover.AVAILABLE_STREAMS")
+    def test_inaccessible_stream_removed_from_catalog(self, mock_available_streams):
+        """Test _apply_access_checks removes inaccessible streams."""
+        mock_stream_class = MagicMock()
+        mock_stream_instance = MagicMock()
+        mock_stream_instance.check_access.return_value = False
+        mock_stream_class.return_value = mock_stream_instance
+
+        mock_available_streams.items.return_value = [
+            ("contacts", mock_stream_class),
+            ("call_log", mock_stream_class)
+        ]
+
+        schemas = {"contacts": {}, "call_log": {}}
+        field_metadata = {"contacts": [], "call_log": []}
+
+        mock_client = MagicMock()
+
+        with self.assertRaises(RingCentralForbiddenError):
+            _apply_access_checks(mock_client, schemas, field_metadata)
+
+    @patch("tap_ringcentral.discover.AVAILABLE_STREAMS")
+    def test_all_inaccessible_raises_forbidden_error(self, mock_available_streams):
+        """Test _apply_access_checks raises error when all streams are inaccessible."""
+        mock_stream_class = MagicMock()
+        mock_stream_instance = MagicMock()
+        mock_stream_instance.check_access.return_value = False
+        mock_stream_class.return_value = mock_stream_instance
+
+        mock_available_streams.items.return_value = [("contacts", mock_stream_class)]
+
+        schemas = {"contacts": {}}
+        field_metadata = {"contacts": []}
+
+        mock_client = MagicMock()
+
+        with self.assertRaises(RingCentralForbiddenError) as context:
+            _apply_access_checks(mock_client, schemas, field_metadata)
+
+        self.assertIn("403", str(context.exception))
+
+
+class TestPruneInaccessibleChildren(unittest.TestCase):
+    """
+    Unit tests for the _prune_inaccessible_children function.
+    """
+
+    @patch("tap_ringcentral.discover.AVAILABLE_STREAMS")
+    def test_child_pruned_when_parent_missing(self, mock_available_streams):
+        """Test child stream is removed when parent stream is not in schemas."""
+        # Create a mock child stream class with parent attribute
+        mock_child_class = MagicMock()
+        mock_child_class.parent = "contacts"
+
+        # Create a mock parent stream class without parent attribute
+        mock_parent_class = MagicMock()
+        del mock_parent_class.parent
+
+        mock_available_streams.items.return_value = [
+            ("contacts", mock_parent_class),
+            ("call_log", mock_child_class),
+        ]
+
+        schemas = {"call_log": {}}  # Parent "contacts" is missing
+        field_metadata = {"call_log": []}
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertNotIn("call_log", schemas)
+        self.assertNotIn("call_log", field_metadata)
+
+    @patch("tap_ringcentral.discover.AVAILABLE_STREAMS")
+    def test_child_kept_when_parent_present(self, mock_available_streams):
+        """Test child stream is kept when parent stream is in schemas."""
+        mock_child_class = MagicMock()
+        mock_child_class.parent = "contacts"
+
+        mock_parent_class = MagicMock()
+        del mock_parent_class.parent
+
+        mock_available_streams.items.return_value = [
+            ("contacts", mock_parent_class),
+            ("call_log", mock_child_class),
+        ]
+
+        schemas = {"contacts": {}, "call_log": {}}
+        field_metadata = {"contacts": [], "call_log": []}
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertIn("call_log", schemas)
+        self.assertIn("call_log", field_metadata)
+
+    @patch("tap_ringcentral.discover.AVAILABLE_STREAMS")
+    def test_no_parent_streams_at_all(self, mock_available_streams):
+        """Test function handles case where no streams have parents."""
+        mock_parent_class = MagicMock()
+        del mock_parent_class.parent
+
+        mock_available_streams.items.return_value = [
+            ("contacts", mock_parent_class),
+            ("messages", mock_parent_class),
+        ]
+
+        schemas = {"contacts": {}, "messages": {}}
+        field_metadata = {"contacts": [], "messages": []}
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertIn("contacts", schemas)
+        self.assertIn("messages", schemas)

--- a/tests/unittests/test_main.py
+++ b/tests/unittests/test_main.py
@@ -1,0 +1,201 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+import sys
+from io import StringIO
+
+from tap_ringcentral import RingCentralRunner, main
+
+
+class TestRingCentralRunner(unittest.TestCase):
+    """
+    Unit tests for the RingCentralRunner class in tap_ringcentral/__init__.py
+    """
+
+    def setUp(self):
+        """Set up common test configuration before each test case runs."""
+        self.config = {
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token": "test_refresh_token",
+            "api_url": "https://platform.ringcentral.com",
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+        self.state = {}
+
+        self.mock_client = MagicMock()
+        self.mock_args = MagicMock()
+        self.mock_args.config = self.config
+        self.mock_args.state = self.state
+        self.mock_args.catalog = MagicMock()
+        self.mock_args.discover = False
+        self.mock_args.catalog = False
+
+    def test_runner_init(self):
+        """Test that RingCentralRunner initializes correctly."""
+        runner = RingCentralRunner(self.mock_args, self.mock_client)
+        self.assertEqual(runner.config, self.config)
+        self.assertEqual(runner.state, self.state)
+        self.assertEqual(runner.catalog, self.mock_args.catalog)
+        self.assertEqual(runner.client, self.mock_client)
+        self.assertIsNotNone(runner.available_streams)
+
+    @patch("tap_ringcentral.singer.write_state")
+    def test_save_state_with_valid_state(self, mock_write_state):
+        """Test that save_state writes state when state is provided."""
+        runner = RingCentralRunner(self.mock_args, self.mock_client)
+        state = {"bookmarks": {"contacts": {"last_record": "2025-01-01T00:00:00Z"}}}
+        runner.save_state(state)
+        mock_write_state.assert_called_once_with(state)
+
+    @patch("tap_ringcentral.singer.write_state")
+    def test_save_state_with_none_state(self, mock_write_state):
+        """Test that save_state does nothing when state is None."""
+        runner = RingCentralRunner(self.mock_args, self.mock_client)
+        runner.save_state(None)
+        mock_write_state.assert_not_called()
+
+    @patch("tap_ringcentral.singer.write_state")
+    def test_save_state_with_empty_state(self, mock_write_state):
+        """Test that save_state does nothing when state is empty."""
+        runner = RingCentralRunner(self.mock_args, self.mock_client)
+        runner.save_state({})
+        mock_write_state.assert_not_called()
+
+    @patch("tap_ringcentral.json.dump")
+    @patch("tap_ringcentral.discover")
+    def test_do_discover(self, mock_discover, mock_json_dump):
+        """Test that do_discover calls discover and outputs catalog."""
+        mock_catalog = MagicMock()
+        mock_catalog.to_dict.return_value = {"streams": []}
+        mock_discover.return_value = mock_catalog
+
+        runner = RingCentralRunner(self.mock_args, self.mock_client)
+        runner.do_discover()
+
+        mock_discover.assert_called_once_with(self.mock_client)
+        mock_json_dump.assert_called_once()
+
+    def test_do_sync_with_no_selected_streams(self):
+        """Test do_sync when catalog has no selected streams."""
+        self.mock_args.catalog = MagicMock()
+        self.mock_args.catalog.get_selected_streams.return_value = []
+
+        runner = RingCentralRunner(self.mock_args, self.mock_client)
+        runner.do_sync()
+
+        # Should not raise any exception
+        self.mock_args.catalog.get_selected_streams.assert_called_once_with(self.state)
+
+    def test_do_sync_with_selected_streams(self):
+        """Test do_sync syncs selected streams."""
+        # Setup mock stream
+        mock_stream_obj = MagicMock()
+        mock_stream_obj.TABLE = "test_stream"
+        mock_stream_obj.state = self.state
+        mock_stream_obj.sync.return_value = None
+
+        # Setup mock catalog
+        mock_catalog_entry = MagicMock()
+        mock_catalog_entry.stream = "test_stream"
+
+        self.mock_args.catalog = MagicMock()
+        self.mock_args.catalog.get_selected_streams.return_value = [mock_catalog_entry]
+
+        # Mock the stream class
+        with patch.dict("tap_ringcentral.AVAILABLE_STREAMS", {"test_stream": MagicMock(return_value=mock_stream_obj)}):
+            runner = RingCentralRunner(self.mock_args, self.mock_client)
+            runner.do_sync()
+
+            mock_stream_obj.sync.assert_called_once()
+
+    def test_do_sync_with_stream_exception(self):
+        """Test do_sync raises exception when stream sync fails."""
+        # Setup mock stream that raises exception
+        mock_stream_obj = MagicMock()
+        mock_stream_obj.TABLE = "test_stream"
+        mock_stream_obj.state = self.state
+        mock_stream_obj.sync.side_effect = Exception("Sync failed")
+
+        # Setup mock catalog
+        mock_catalog_entry = MagicMock()
+        mock_catalog_entry.stream = "test_stream"
+
+        self.mock_args.catalog = MagicMock()
+        self.mock_args.catalog.get_selected_streams.return_value = [mock_catalog_entry]
+
+        # Mock the stream class
+        with patch.dict("tap_ringcentral.AVAILABLE_STREAMS", {"test_stream": MagicMock(return_value=mock_stream_obj)}):
+            runner = RingCentralRunner(self.mock_args, self.mock_client)
+            with self.assertRaises(Exception):
+                runner.do_sync()
+
+
+class TestMainFunction(unittest.TestCase):
+    """
+    Unit tests for the main function in tap_ringcentral/__init__.py
+    """
+
+    @patch("tap_ringcentral.RingCentralRunner")
+    @patch("tap_ringcentral.RingCentralClient")
+    @patch("tap_ringcentral.singer.utils.parse_args")
+    def test_main_discover_mode(self, mock_parse_args, mock_client_class, mock_runner_class):
+        """Test main function in discover mode."""
+        mock_args = MagicMock()
+        mock_args.config = {"client_id": "test"}
+        mock_args.config_path = "/path/to/config"
+        mock_args.discover = True
+        mock_args.catalog = None
+        mock_parse_args.return_value = mock_args
+
+        mock_runner = MagicMock()
+        mock_runner_class.return_value = mock_runner
+
+        main()
+
+        mock_parse_args.assert_called_once()
+        mock_client_class.assert_called_once_with(mock_args.config, mock_args.config_path)
+        mock_runner_class.assert_called_once()
+        mock_runner.do_discover.assert_called_once()
+        mock_runner.do_sync.assert_not_called()
+
+    @patch("tap_ringcentral.RingCentralRunner")
+    @patch("tap_ringcentral.RingCentralClient")
+    @patch("tap_ringcentral.singer.utils.parse_args")
+    def test_main_sync_mode(self, mock_parse_args, mock_client_class, mock_runner_class):
+        """Test main function in sync mode."""
+        mock_args = MagicMock()
+        mock_args.config = {"client_id": "test"}
+        mock_args.config_path = "/path/to/config"
+        mock_args.discover = False
+        mock_args.catalog = MagicMock()
+        mock_parse_args.return_value = mock_args
+
+        mock_runner = MagicMock()
+        mock_runner_class.return_value = mock_runner
+
+        main()
+
+        mock_parse_args.assert_called_once()
+        mock_runner.do_sync.assert_called_once()
+        mock_runner.do_discover.assert_not_called()
+
+    @patch("tap_ringcentral.RingCentralRunner")
+    @patch("tap_ringcentral.RingCentralClient")
+    @patch("tap_ringcentral.singer.utils.parse_args")
+    def test_main_neither_discover_nor_sync(self, mock_parse_args, mock_client_class, mock_runner_class):
+        """Test main function when neither discover nor sync is specified."""
+        mock_args = MagicMock()
+        mock_args.config = {"client_id": "test"}
+        mock_args.config_path = "/path/to/config"
+        mock_args.discover = False
+        mock_args.catalog = None  # No catalog provided
+        mock_parse_args.return_value = mock_args
+
+        mock_runner = MagicMock()
+        mock_runner_class.return_value = mock_runner
+
+        main()
+
+        # Neither should be called
+        mock_runner.do_discover.assert_not_called()
+        mock_runner.do_sync.assert_not_called()

--- a/tests/unittests/test_main_entry.py
+++ b/tests/unittests/test_main_entry.py
@@ -1,0 +1,17 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+
+
+class TestMainEntry(unittest.TestCase):
+    """
+    Unit tests for the main entry point when run as script.
+    """
+
+    @patch("tap_ringcentral.main")
+    def test_main_entry_point(self, mock_main):
+        """Test that main is called when module is run as __main__."""
+        # This test documents that the __main__ block calls main()
+        # The actual execution is handled by Python's import mechanism
+        # This test verifies the pattern is correct
+        self.assertTrue(callable(mock_main))

--- a/tests/unittests/test_schema.py
+++ b/tests/unittests/test_schema.py
@@ -1,0 +1,84 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from tap_ringcentral.schema import get_schemas, get_abs_path
+import os
+import json
+
+
+class TestGetAbsPath(unittest.TestCase):
+    """
+    Unit tests for the get_abs_path function in tap_ringcentral/schema.py
+    """
+
+    def test_get_abs_path_returns_absolute_path(self):
+        """Test that get_abs_path returns an absolute path."""
+        result = get_abs_path("schemas/contacts.json")
+        self.assertTrue(os.path.isabs(result))
+
+    def test_get_abs_path_contains_schema_directory(self):
+        """Test that get_abs_path includes the schema directory."""
+        result = get_abs_path("schemas/contacts.json")
+        self.assertIn("schemas/contacts.json", result)
+
+    def test_get_abs_path_with_different_files(self):
+        """Test that get_abs_path works with different file names."""
+        path1 = get_abs_path("schemas/contacts.json")
+        path2 = get_abs_path("schemas/call_log.json")
+        self.assertNotEqual(path1, path2)
+        self.assertIn("contacts.json", path1)
+        self.assertIn("call_log.json", path2)
+
+
+class TestGetSchemas(unittest.TestCase):
+    """
+    Unit tests for the get_schemas function in tap_ringcentral/schema.py
+    """
+
+    def test_get_schemas_returns_two_dicts(self):
+        """Test that get_schemas returns two dictionaries."""
+        schemas, field_metadata = get_schemas()
+        self.assertIsInstance(schemas, dict)
+        self.assertIsInstance(field_metadata, dict)
+
+    def test_get_schemas_schemas_not_empty(self):
+        """Test that returned schemas dictionary is not empty."""
+        schemas, field_metadata = get_schemas()
+        self.assertGreater(len(schemas), 0)
+
+    def test_get_schemas_field_metadata_not_empty(self):
+        """Test that returned field_metadata dictionary is not empty."""
+        schemas, field_metadata = get_schemas()
+        self.assertGreater(len(field_metadata), 0)
+
+    def test_get_schemas_same_keys(self):
+        """Test that schemas and field_metadata have the same keys."""
+        schemas, field_metadata = get_schemas()
+        self.assertEqual(set(schemas.keys()), set(field_metadata.keys()))
+
+    def test_get_schemas_contains_expected_streams(self):
+        """Test that schemas includes expected stream names."""
+        schemas, field_metadata = get_schemas()
+        expected_streams = ["call_log", "company_call_log", "contacts", "messages"]
+        for stream in expected_streams:
+            self.assertIn(stream, schemas)
+
+    def test_get_schemas_schema_has_properties(self):
+        """Test that each schema has a properties key."""
+        schemas, field_metadata = get_schemas()
+        for stream_name, schema in schemas.items():
+            self.assertIn("properties", schema, f"Schema for {stream_name} missing properties")
+
+    def test_get_schemas_field_metadata_is_list(self):
+        """Test that field_metadata values are lists."""
+        schemas, field_metadata = get_schemas()
+        for stream_name, mdata in field_metadata.items():
+            self.assertIsInstance(mdata, list, f"Metadata for {stream_name} is not a list")
+
+    def test_get_schemas_metadata_has_table_key_properties(self):
+        """Test that metadata includes table-key-properties."""
+        from singer.metadata import to_map
+        schemas, field_metadata = get_schemas()
+        for stream_name, mdata in field_metadata.items():
+            mdata_map = to_map(mdata)
+            self.assertIn((), mdata_map)
+            self.assertIn("table-key-properties", mdata_map[()])

--- a/tests/unittests/test_schema_replication.py
+++ b/tests/unittests/test_schema_replication.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from tap_ringcentral.schema import get_schemas
+
+
+class TestGetSchemasWithReplicationKeys(unittest.TestCase):
+    """
+    Unit tests for get_schemas when streams have REPLICATION_KEYS.
+    """
+
+    @patch("tap_ringcentral.schema.AVAILABLE_STREAMS")
+    @patch("builtins.open")
+    def test_get_schemas_marks_replication_keys_as_automatic(self, mock_open_file, mock_available_streams):
+        """Test that get_schemas marks REPLICATION_KEYS as automatic inclusion."""
+        # Create a mock stream with REPLICATION_KEYS
+        mock_stream_class = MagicMock()
+        mock_stream_class.KEY_PROPERTIES = ["id"]
+        mock_stream_class.REPLICATION_KEYS = ["updated_at"]  # This field should be marked automatic
+        mock_stream_class.REPLICATION_METHOD = "INCREMENTAL"
+
+        mock_available_streams.items.return_value = [("messages", mock_stream_class)]
+
+        # Mock the schema file
+        schema_dict = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "updated_at": {"type": "string"},
+            }
+        }
+
+        mock_open_file.return_value.__enter__.return_value.read.return_value = str(schema_dict)
+
+        with patch("tap_ringcentral.schema.json.load", return_value=schema_dict):
+            schemas, field_metadata = get_schemas()
+
+        # Verify both dicts returned
+        self.assertIn("messages", schemas)
+        self.assertIn("messages", field_metadata)
+
+        # Verify metadata includes the stream
+        self.assertIsNotNone(field_metadata["messages"])

--- a/tests/unittests/test_state_load.py
+++ b/tests/unittests/test_state_load.py
@@ -1,0 +1,59 @@
+import unittest
+from unittest.mock import patch, MagicMock, mock_open
+import json
+import os
+
+from tap_ringcentral.state import load_state
+
+
+class TestLoadState(unittest.TestCase):
+    """
+    Unit tests for the load_state function in tap_ringcentral/state.py
+    """
+
+    def test_load_state_with_none_filename(self):
+        """Test that load_state returns empty dict when filename is None."""
+        result = load_state(None)
+        self.assertEqual(result, {})
+
+    @patch("builtins.open", new_callable=mock_open, read_data='{"bookmarks": {"contacts": {"last_record": "2025-01-01T00:00:00Z"}}}')
+    def test_load_state_with_valid_file(self, mock_file):
+        """Test that load_state loads and returns state from valid JSON file."""
+        result = load_state("/path/to/state.json")
+        self.assertIn("bookmarks", result)
+        self.assertIn("contacts", result["bookmarks"])
+        mock_file.assert_called_once_with("/path/to/state.json")
+
+    @patch("builtins.open", new_callable=mock_open, read_data='{}')
+    def test_load_state_with_empty_json(self, mock_file):
+        """Test that load_state returns empty dict from empty JSON file."""
+        result = load_state("/path/to/state.json")
+        self.assertEqual(result, {})
+
+    @patch("builtins.open", new_callable=mock_open)
+    def test_load_state_with_invalid_json(self, mock_file):
+        """Test that load_state raises RuntimeError on invalid JSON."""
+        mock_file.side_effect = json.JSONDecodeError("Expecting value", "", 0)
+        with self.assertRaises(RuntimeError):
+            load_state("/path/to/invalid.json")
+
+    @patch("builtins.open", side_effect=FileNotFoundError())
+    def test_load_state_with_nonexistent_file(self, mock_file):
+        """Test that load_state raises RuntimeError when file does not exist."""
+        with self.assertRaises(RuntimeError):
+            load_state("/path/to/nonexistent.json")
+
+    @patch("builtins.open", new_callable=mock_open, read_data='{"bookmarks": {"contacts": {"field": "last_record", "last_record": "2025-01-01T00:00:00Z"}, "messages": {"field": "last_record", "last_record": "2025-01-02T00:00:00Z"}}}')
+    def test_load_state_with_multiple_bookmarks(self, mock_file):
+        """Test that load_state correctly loads multiple bookmarks."""
+        result = load_state("/path/to/state.json")
+        self.assertEqual(len(result["bookmarks"]), 2)
+        self.assertIn("contacts", result["bookmarks"])
+        self.assertIn("messages", result["bookmarks"])
+
+    @patch("builtins.open", new_callable=mock_open, read_data='{"bookmarks": {}, "other_key": "other_value"}')
+    def test_load_state_preserves_additional_keys(self, mock_file):
+        """Test that load_state preserves additional keys in state."""
+        result = load_state("/path/to/state.json")
+        self.assertIn("other_key", result)
+        self.assertEqual(result["other_key"], "other_value")

--- a/tests/unittests/test_streams_advanced.py
+++ b/tests/unittests/test_streams_advanced.py
@@ -1,0 +1,227 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+from datetime import datetime, timedelta
+import pytz
+
+from tap_ringcentral.streams.base import BaseStream, ContactBaseStream
+from tap_ringcentral.streams.contacts import ContactsStream
+from tap_ringcentral.streams.company_call_log import CompanyCallLogStream
+
+
+class TestBaseStreamTransform(unittest.TestCase):
+    """
+    Unit tests for the transform_record and get_schema methods of BaseStream.
+    """
+
+    def setUp(self):
+        """Set up common test configuration before each test case runs."""
+        self.config = {
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token": "test_refresh_token",
+            "api_url": "https://platform.ringcentral.com",
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+        self.state = {}
+
+        self.mock_catalog = MagicMock()
+        self.mock_catalog.stream = "test_stream"
+        self.mock_catalog.tap_stream_id = "test_stream"
+        self.mock_catalog.schema.to_dict.return_value = {
+            "type": "object",
+            "properties": {"id": {"type": "string"}, "name": {"type": "string"}}
+        }
+        self.mock_catalog.key_properties = ["id"]
+        self.mock_catalog.metadata = None
+
+        self.mock_client = MagicMock()
+        self.mock_client.base_url = "https://platform.ringcentral.com"
+
+    @patch("tap_ringcentral.streams.base.singer.Transformer")
+    def test_transform_record_with_metadata(self, mock_transformer_class):
+        """Test transform_record applies metadata when available."""
+        mock_transformer = MagicMock()
+        mock_transformer_class.return_value.__enter__.return_value = mock_transformer
+        mock_transformer.transform.return_value = {"id": "1", "name": "Test"}
+
+        # Add metadata to catalog
+        self.mock_catalog.metadata = [
+            {"breadcrumb": [], "metadata": {"table-key-properties": ["id"]}}
+        ]
+
+        stream = BaseStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        record = {"id": "1", "name": "Test"}
+
+        result = stream.transform_record(record)
+
+        mock_transformer.transform.assert_called_once()
+        self.assertEqual(result, {"id": "1", "name": "Test"})
+
+    @patch("tap_ringcentral.streams.base.singer.Transformer")
+    def test_transform_record_without_metadata(self, mock_transformer_class):
+        """Test transform_record works with no metadata."""
+        mock_transformer = MagicMock()
+        mock_transformer_class.return_value.__enter__.return_value = mock_transformer
+        mock_transformer.transform.return_value = {"id": "1"}
+
+        stream = BaseStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        record = {"id": "1"}
+
+        result = stream.transform_record(record)
+
+        mock_transformer.transform.assert_called_once()
+        call_args = mock_transformer.transform.call_args
+        # Verify metadata dict is empty when catalog.metadata is None
+        self.assertEqual(call_args[0][2], {})
+
+    def test_get_schema_loads_schema_by_table_name(self):
+        """Test get_schema loads schema using TABLE name."""
+        stream = BaseStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        stream.TABLE = "contacts"
+
+        with patch.object(stream, "load_schema_by_name") as mock_load:
+            mock_load.return_value = {"type": "object"}
+            stream.get_schema()
+            mock_load.assert_called_once_with("contacts")
+
+    def test_get_class_path_returns_directory(self):
+        """Test get_class_path returns the directory of the class file."""
+        stream = BaseStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        path = stream.get_class_path()
+        self.assertIsNotNone(path)
+        self.assertTrue(len(path) > 0)
+
+    def test_get_url_constructs_full_url(self):
+        """Test get_url constructs full URL from base and path."""
+        stream = BaseStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        # Note: BASE_URL must be defined in the base.py module for this to work
+        # This test documents current behavior
+
+
+class TestContactsStreamGetStreamData(unittest.TestCase):
+    """
+    Unit tests for the ContactsStream.get_stream_data method.
+    """
+
+    def setUp(self):
+        """Set up common test configuration before each test case runs."""
+        self.config = {
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token": "test_refresh_token",
+            "api_url": "https://platform.ringcentral.com",
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+        self.state = {}
+
+        self.mock_catalog = MagicMock()
+        self.mock_catalog.stream = "contacts"
+        self.mock_catalog.metadata = None
+
+        self.mock_client = MagicMock()
+        self.mock_client.base_url = "https://platform.ringcentral.com"
+
+    @patch("tap_ringcentral.streams.contacts.tap_ringcentral.cache.contacts")
+    def test_get_stream_data_extends_cache(self, mock_cache):
+        """Test get_stream_data adds contacts to cache."""
+        mock_cache.extend = MagicMock()
+
+        stream = ContactsStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        stream.transform_record = MagicMock(side_effect=lambda r: r)
+
+        result = {"records": [{"id": "1", "name": "Contact 1"}, {"id": "2", "name": "Contact 2"}]}
+
+        data = stream.get_stream_data(result)
+
+        # Verify cache.extend was called
+        mock_cache.extend.assert_called_once()
+        # Verify returned data matches
+        self.assertEqual(len(data), 2)
+
+
+class TestCompanyCallLogStreamSyncDataForPeriod(unittest.TestCase):
+    """
+    Unit tests for the CompanyCallLogStream.sync_data_for_period method.
+    """
+
+    def setUp(self):
+        """Set up common test configuration before each test case runs."""
+        self.config = {
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token": "test_refresh_token",
+            "api_url": "https://platform.ringcentral.com",
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+        self.state = {}
+
+        self.mock_catalog = MagicMock()
+        self.mock_catalog.stream = "company_call_log"
+        self.mock_catalog.metadata = None
+
+        self.mock_client = MagicMock()
+        self.mock_client.base_url = "https://platform.ringcentral.com"
+
+    def test_sync_data_for_period_calls_sync_for_extension_with_none(self):
+        """Test CompanyCallLogStream.sync_data_for_period calls sync_data_for_extension with None extensionId."""
+        stream = CompanyCallLogStream(self.config, self.state, self.mock_catalog, self.mock_client)
+
+        # Mock sync_data_for_extension instead of trying to run it
+        with patch.object(stream, 'sync_data_for_extension') as mock_sync:
+            date = datetime(2025, 1, 1, tzinfo=pytz.utc)
+            interval = timedelta(days=7)
+
+            stream.sync_data_for_period(date, interval)
+
+            # Verify sync_data_for_extension was called with None instead of iterating contacts
+            mock_sync.assert_called_once_with(date, interval, None)
+
+    def test_sync_data_for_period_returns_updated_state(self):
+        """Test sync_data_for_period updates state with new bookmark."""
+        stream = CompanyCallLogStream(self.config, self.state, self.mock_catalog, self.mock_client)
+
+        with patch.object(stream, 'sync_data_for_extension'):
+            date = datetime(2025, 1, 1, tzinfo=pytz.utc)
+            interval = timedelta(days=7)
+
+            result = stream.sync_data_for_period(date, interval)
+
+            self.assertIn("bookmarks", result)
+            self.assertIn("company_call_log", result["bookmarks"])
+
+
+class TestBaseStreamGetStreamDataWithContactId(unittest.TestCase):
+    """
+    Unit tests for BaseStream.get_stream_data with contact_id parameter.
+    """
+
+    def setUp(self):
+        """Set up common test configuration before each test case runs."""
+        self.config = {
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token": "test_refresh_token",
+            "api_url": "https://platform.ringcentral.com",
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+        self.state = {}
+
+        self.mock_catalog = MagicMock()
+        self.mock_catalog.metadata = None
+
+        self.mock_client = MagicMock()
+        self.mock_client.base_url = "https://platform.ringcentral.com"
+
+    def test_get_stream_data_processes_records_and_adds_contact_id(self):
+        """Test get_stream_data adds contact_id to each record."""
+        stream = BaseStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        stream.transform_record = MagicMock(side_effect=lambda r: r)
+
+        result = {"records": [{"id": "1"}, {"id": "2"}]}
+        contact_id = "ext123"
+
+        data = stream.get_stream_data(result, contact_id)
+
+        self.assertEqual(len(data), 2)
+        for record in data:
+            self.assertEqual(record["_contact_id"], contact_id)

--- a/tests/unittests/test_streams_sync.py
+++ b/tests/unittests/test_streams_sync.py
@@ -1,0 +1,315 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+import time
+from datetime import datetime, timedelta
+import pytz
+
+from tap_ringcentral.streams.base import BaseStream, ContactBaseStream
+from tap_ringcentral.client import RingCentralForbiddenError
+
+
+class TestBaseStreamSyncData(unittest.TestCase):
+    """
+    Unit tests for the sync_data method of BaseStream class.
+    """
+
+    def setUp(self):
+        """Set up common test configuration before each test case runs."""
+        self.config = {
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token": "test_refresh_token",
+            "api_url": "https://platform.ringcentral.com",
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+        self.state = {}
+
+        self.mock_catalog = MagicMock()
+        self.mock_catalog.stream = "test_stream"
+        self.mock_catalog.tap_stream_id = "test_stream"
+        self.mock_catalog.schema.to_dict.return_value = {
+            "type": "object",
+            "properties": {"id": {"type": "string"}}
+        }
+        self.mock_catalog.key_properties = ["id"]
+        self.mock_catalog.metadata = None
+
+        self.mock_client = MagicMock()
+        self.mock_client.base_url = "https://platform.ringcentral.com"
+
+    @patch("tap_ringcentral.streams.base.singer.write_records")
+    @patch("tap_ringcentral.streams.base.singer.metrics.record_counter")
+    def test_sync_data_single_page(self, mock_counter_context, mock_write_records):
+        """Test sync_data with single page of results."""
+        stream = BaseStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        stream.TABLE = "test_table"
+        stream.API_METHOD = "GET"
+        stream.api_path = "/test/path"
+
+        # Mock transform_record to return record as-is
+        stream.transform_record = MagicMock(side_effect=lambda r: r)
+
+        # Override get_stream_data to handle no contact_id
+        stream.get_stream_data = MagicMock(return_value=[{"id": "1", "name": "Test 1"}])
+
+        # Mock API response
+        self.mock_client.make_request.return_value = {
+            "records": [{"id": "1", "name": "Test 1"}],
+            "paging": {"totalPages": 1}
+        }
+
+        # Mock the record counter context manager
+        mock_counter = MagicMock()
+        mock_counter_context.return_value.__enter__.return_value = mock_counter
+
+        stream.sync_data()
+
+        # Verify API was called
+        self.mock_client.make_request.assert_called_once()
+        # Verify records were written
+        mock_write_records.assert_called_once()
+
+    @patch("tap_ringcentral.streams.base.singer.write_records")
+    @patch("tap_ringcentral.streams.base.singer.metrics.record_counter")
+    def test_sync_data_multiple_pages(self, mock_counter_context, mock_write_records):
+        """Test sync_data with multiple pages of results."""
+        stream = BaseStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        stream.TABLE = "test_table"
+        stream.API_METHOD = "GET"
+        stream.api_path = "/test/path"
+
+        stream.transform_record = MagicMock(side_effect=lambda r: r)
+        stream.get_stream_data = MagicMock(side_effect=[
+            [{"id": "1"}],
+            [{"id": "2"}]
+        ])
+
+        # Mock API responses for pages 1 and 2
+        page_1_response = {
+            "records": [{"id": "1"}],
+            "paging": {"totalPages": 2}
+        }
+        page_2_response = {
+            "records": [{"id": "2"}],
+            "paging": {"totalPages": 2}
+        }
+
+        self.mock_client.make_request.side_effect = [page_1_response, page_2_response]
+
+        mock_counter = MagicMock()
+        mock_counter_context.return_value.__enter__.return_value = mock_counter
+
+        stream.sync_data()
+
+        # Verify API was called twice
+        self.assertEqual(self.mock_client.make_request.call_count, 2)
+        # Verify records were written twice
+        self.assertEqual(mock_write_records.call_count, 2)
+
+    def test_check_access_returns_true_for_accessible_stream(self):
+        """Test check_access returns True when stream is accessible."""
+        stream = BaseStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        stream.api_path = "/test/path"
+        stream.API_METHOD = "GET"
+
+        # Mock successful API call
+        self.mock_client.make_request.return_value = {"data": "success"}
+
+        result = stream.check_access()
+
+        self.assertTrue(result)
+        self.mock_client.make_request.assert_called_once()
+
+    def test_check_access_returns_false_for_forbidden_stream(self):
+        """Test check_access returns False when stream returns 403 Forbidden."""
+        stream = BaseStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        stream.api_path = "/test/path"
+        stream.API_METHOD = "GET"
+
+        # Mock forbidden error
+        self.mock_client.make_request.side_effect = RingCentralForbiddenError("HTTP-error-code: 403")
+
+        result = stream.check_access()
+
+        self.assertFalse(result)
+
+    def test_check_access_always_true_for_child_stream(self):
+        """Test check_access returns True for child streams."""
+        stream = BaseStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        stream.parent = "parent_stream"
+
+        result = stream.check_access()
+
+        self.assertTrue(result)
+        # Verify API was NOT called for child stream
+        self.mock_client.make_request.assert_not_called()
+
+    def test_check_access_replaces_placeholders_in_url(self):
+        """Test check_access replaces placeholders with ~ in URL."""
+        stream = BaseStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        stream.api_path = "/restapi/v1.0/account/~/extension/{extensionId}/call-log"
+        stream.API_METHOD = "GET"
+
+        self.mock_client.make_request.return_value = {"data": "success"}
+
+        stream.check_access()
+
+        # Verify the URL passed has placeholders replaced with ~
+        call_args = self.mock_client.make_request.call_args
+        called_url = call_args[0][0]
+        self.assertIn("~/extension/~", called_url)
+
+
+class TestContactBaseStreamSyncData(unittest.TestCase):
+    """
+    Unit tests for the sync_data and related methods of ContactBaseStream class.
+    """
+
+    def setUp(self):
+        """Set up common test configuration before each test case runs."""
+        self.config = {
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token": "test_refresh_token",
+            "api_url": "https://platform.ringcentral.com",
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+        self.state = {}
+
+        self.mock_catalog = MagicMock()
+        self.mock_catalog.stream = "test_stream"
+        self.mock_catalog.tap_stream_id = "test_stream"
+        self.mock_catalog.schema.to_dict.return_value = {
+            "type": "object",
+            "properties": {"id": {"type": "string"}}
+        }
+        self.mock_catalog.key_properties = ["id"]
+        self.mock_catalog.metadata = None
+
+        self.mock_client = MagicMock()
+        self.mock_client.base_url = "https://platform.ringcentral.com"
+
+    @patch("tap_ringcentral.streams.base.tap_ringcentral.cache.contacts", [])
+    @patch("tap_ringcentral.streams.base.save_state")
+    @patch("tap_ringcentral.streams.base.get_last_record_value_for_table")
+    @patch("tap_ringcentral.streams.base.get_config_start_date")
+    def test_sync_data_with_no_previous_state(self, mock_get_start_date, mock_get_last_record, mock_save_state):
+        """Test sync_data uses start_date when no previous state exists."""
+        stream = ContactBaseStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        stream.TABLE = "test_table"
+        stream.API_METHOD = "GET"
+        stream.api_path = "/test/path/{extensionId}"
+
+        # Mock no previous bookmark
+        mock_get_last_record.return_value = None
+        start_date = datetime(2025, 1, 1, tzinfo=pytz.utc)
+        mock_get_start_date.return_value = start_date
+
+        # Mock sync_data_for_period
+        stream.sync_data_for_period = MagicMock()
+
+        stream.sync_data()
+
+        # Verify get_config_start_date was called
+        mock_get_start_date.assert_called_once_with(self.config)
+
+    @patch("tap_ringcentral.streams.base.save_state")
+    def test_sync_data_for_period_returns_updated_state(self, mock_save_state):
+        """Test sync_data_for_period returns updated state."""
+        stream = ContactBaseStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        stream.TABLE = "test_table"
+
+        # Mock sync_data_for_extension
+        stream.sync_data_for_extension = MagicMock()
+
+        date = datetime(2025, 1, 1, tzinfo=pytz.utc)
+        interval = timedelta(days=7)
+
+        with patch("tap_ringcentral.streams.base.tap_ringcentral.cache.contacts", []):
+            result = stream.sync_data_for_period(date, interval)
+
+        self.assertIsNotNone(result)
+        self.assertIn("bookmarks", result)
+
+    @patch("tap_ringcentral.streams.base.time.sleep")
+    @patch("tap_ringcentral.streams.base.singer.write_records")
+    @patch("tap_ringcentral.streams.base.singer.metrics.record_counter")
+    def test_sync_data_for_extension_handles_pagination(self, mock_counter_context, mock_write_records, mock_sleep):
+        """Test sync_data_for_extension stops pagination when data is less than per_page."""
+        stream = ContactBaseStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        stream.TABLE = "test_table"
+        stream.API_METHOD = "GET"
+        stream.api_path = "/test/path/{extensionId}"
+
+        stream.transform_record = MagicMock(side_effect=lambda r: r)
+
+        # Mock API response with fewer records than per_page
+        self.mock_client.make_request.return_value = {
+            "records": [{"id": "1"}],  # Only 1 record, less than per_page=100
+        }
+
+        mock_counter = MagicMock()
+        mock_counter_context.return_value.__enter__.return_value = mock_counter
+
+        date = datetime(2025, 1, 1, tzinfo=pytz.utc)
+        interval = timedelta(days=7)
+
+        stream.sync_data_for_extension(date, interval, "ext123")
+
+        # Verify API was called once (no pagination)
+        self.mock_client.make_request.assert_called_once()
+        # Verify sleep was called for rate limiting
+        mock_sleep.assert_called()
+
+    @patch("tap_ringcentral.streams.base.time.sleep")
+    @patch("tap_ringcentral.streams.base.singer.write_records")
+    @patch("tap_ringcentral.streams.base.singer.metrics.record_counter")
+    def test_sync_data_for_extension_continues_pagination(self, mock_counter_context, mock_write_records, mock_sleep):
+        """Test sync_data_for_extension continues pagination when data reaches per_page."""
+        stream = ContactBaseStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        stream.TABLE = "test_table"
+        stream.API_METHOD = "GET"
+        stream.api_path = "/test/path/{extensionId}"
+
+        stream.transform_record = MagicMock(side_effect=lambda r: r)
+
+        # First page has 100 records, second page has fewer
+        page_1 = {"records": [{"id": str(i)} for i in range(100)]}
+        page_2 = {"records": [{"id": "101"}]}
+
+        self.mock_client.make_request.side_effect = [page_1, page_2]
+
+        mock_counter = MagicMock()
+        mock_counter_context.return_value.__enter__.return_value = mock_counter
+
+        date = datetime(2025, 1, 1, tzinfo=pytz.utc)
+        interval = timedelta(days=7)
+
+        stream.sync_data_for_extension(date, interval, "ext123")
+
+        # Verify API was called twice
+        self.assertEqual(self.mock_client.make_request.call_count, 2)
+
+    @patch("tap_ringcentral.streams.base.time.sleep")
+    def test_sync_data_for_extension_handles_forbidden_error(self, mock_sleep):
+        """Test sync_data_for_extension handles RingCentralForbiddenError gracefully."""
+        stream = ContactBaseStream(self.config, self.state, self.mock_catalog, self.mock_client)
+        stream.TABLE = "messages"
+        stream.API_METHOD = "GET"
+        stream.api_path = "/test/path/{extensionId}"
+
+        stream.transform_record = MagicMock(side_effect=lambda r: r)
+
+        # Mock API to raise forbidden error
+        self.mock_client.make_request.side_effect = RingCentralForbiddenError(
+            "HTTP-error-code: 403, No permission for this extension"
+        )
+
+        date = datetime(2025, 1, 1, tzinfo=pytz.utc)
+        interval = timedelta(days=7)
+
+        # Should NOT raise exception
+        stream.sync_data_for_extension(date, interval, "ext123")
+
+        # Verify the forbidden error was caught
+        self.mock_client.make_request.assert_called_once()


### PR DESCRIPTION
# Description of change
- Added check in discovery for stream authorization.
- The flow now excludes streams with 403 error
- Added unittests to validate the changes
JIRA: https://qlik-dev.atlassian.net/browse/SAC-31235

# Manual QA steps
 - [x] Discovery running
 - [x] Unittests running
 - [x] Integration tests running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
